### PR TITLE
fix/make sure query string is a valid filename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,9 @@ export function handle(i18next, options = {}) {
     let lng = req.lng;
     if (!req.lng && i18next.services.languageDetector) lng = i18next.services.languageDetector.detect(req, res);
 
+    // make sure lng is a plain text file name
+    lng = encodeURIComponent(lng)
+
     // set locale
     req.language = req.locale = req.lng = lng;
     if (!res.headersSent && lng) {


### PR DESCRIPTION
Fixes a potential issue where one could pass an invalid file path into the query string, causing `i18n.changeLanguage` to break. Since `i18next-node-fs-backend` already handles the path, ensuring access would be confined inside the `locales` folder, we only need to ensure the filename we pass in is valid. Hence, I use `encodeURIComponent` to transform the input into a valid filename.

Minimum reproducible example: `<host>?locale=any_random_string%00en` would cause the following error
```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string or Uint8Array without null bytes. Received '/Workspace/Project/locales/any_random_string\x00en.json'
    at Object.readFile (node:fs:411:10)
    at readFile (/Workspace/Project/node_modules/i18next-node-fs-backend/lib/index.js:66:18)
    at Backend.read (/Workspace/Project/node_modules/i18next-node-fs-backend/lib/index.js:128:7)
    at Connector.read (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:1669:34)
    at Connector.loadOne (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:1727:12)
    at /Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:1703:16
    at Array.forEach (<anonymous>)
    at Connector.prepareLoading (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:1702:21)
    at Connector.load (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:1709:12)
    at I18n.loadResources (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:2071:40)
    at setLng (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:2168:16)
    at I18n.changeLanguage (/Workspace/Project/node_modules/i18next/dist/cjs/i18next.js:2178:9)
    at i18nextMiddleware (/Workspace/Project/node_modules/@hackmd/i18next-express-middleware/lib/index.js:78:10)
    at newFn (/Workspace/Project/node_modules/express-async-errors/index.js:16:20)
    at Layer.handle [as handle_request] (/Workspace/Project/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Workspace/Project/node_modules/express/lib/router/index.js:317:13)
    at /Workspace/Project/node_modules/express/lib/router/index.js:284:7
    at Function.process_params (/Workspace/Project/node_modules/express/lib/router/index.js:335:12)
    at next (/Workspace/Project/node_modules/express/lib/router/index.js:275:10)
    at SendStream.error (/Workspace/Project/node_modules/serve-static/index.js:121:7)
    at SendStream.emit (node:events:517:28)
    at SendStream.emit (node:domain:489:12)
    at SendStream.error (/Workspace/Project/node_modules/send/index.js:270:17)
    at SendStream.notFound (/Workspace/Project/node_modules/serve-static/index.js:172:10)
    at SendStream.emit (node:events:517:28)
    at SendStream.emit (node:domain:489:12)
    at SendStream.redirect (/Workspace/Project/node_modules/send/index.js:479:10)
    at onstat (/Workspace/Project/node_modules/send/index.js:728:41)
```